### PR TITLE
GoogLeNet

### DIFF
--- a/src/data/roadmaps/deeplearning/GoogLeNet.md
+++ b/src/data/roadmaps/deeplearning/GoogLeNet.md
@@ -1,0 +1,15 @@
+# What is GoogLeNet?
+
+## GoogLeNet is a convolutional neural network that is 22 layers deep.It is a variant of the Inception Network, developed by researchers at Google. It utilises Inception modules to choose between multiple convolutional filter sizes in each block, with occasional max-pooling layers with stride 2 to halve the number of filter sizes.
+
+# Sources of GoogLeNet:
+
+[GoogLeNet](https://www.mathworks.com/help/deeplearning/ref/googlenet.html)
+
+[GoogLeNet GN](https://paperswithcode.com/method/googlenet)
+
+[GoogLeNet Guide](https://www.geeksforgeeks.org/understanding-googlenet-model-cnn-architecture/)
+
+[GoogLeNet Tutorial](https://pytorch.org/hub/pytorch_vision_googlenet/)
+
+[Learn GoogLeNet](https://d2l.ai/chapter_convolutional-modern/googlenet.html)


### PR DESCRIPTION
GoogLeNet is a convolutional neural network that is 22 layers deep.01 It is a variant of the Inception Network, developed by researchers at Google. it utilises Inception modules to choose between multiple convolutional filter sizes in each block, with occasional max-pooling layers with stride 2 to halve the number of filter sizes.